### PR TITLE
Remove text colors

### DIFF
--- a/src/LibModbus.jl
+++ b/src/LibModbus.jl
@@ -169,10 +169,8 @@ function Base.show(io::IO, ctx::ModbusContext)
         str = "ModbusContext"
     end
     if !ctx.valid
-        color = :red
         str *= "(NULL)"
     elseif ctx isa RtuContext
-        color = :green
         str *= "(serial_port $(ctx.serial_port), baud $(ctx.baud), "*
             "parity $(ctx.parity), data_bits $(ctx.data_bits), "*
             "stop_bits $(ctx.stop_bits))"
@@ -181,7 +179,7 @@ function Base.show(io::IO, ctx::ModbusContext)
     else
         str *= "()"
     end
-    printstyled(io, str; color)
+    printstyled(io, str)
 end
 
 function Base.setproperty!(ctx::ModbusContext, name::Symbol, x)

--- a/src/LibModbus.jl
+++ b/src/LibModbus.jl
@@ -179,7 +179,7 @@ function Base.show(io::IO, ctx::ModbusContext)
     else
         str *= "()"
     end
-    printstyled(io, str)
+    print(io, str)
 end
 
 function Base.setproperty!(ctx::ModbusContext, name::Symbol, x)

--- a/test/unit_test_client.jl
+++ b/test/unit_test_client.jl
@@ -347,7 +347,7 @@ function unit_test_client(verbose=true)
             #
             rc,rp_bits = report_slave_id(ctx_cl, NB_REPORT_SLAVE_ID)
             # Run status indicator is ON
-            @test rc > 1 && rp_bits[2] == 0xFF
+            @test_broken rc > 1 && rp_bits[2] == 0xFF
             length(rp_bits) > 2 && println(String(rp_bits[3:end]))
 
             # Save original timeout

--- a/test/unit_test_client.jl
+++ b/test/unit_test_client.jl
@@ -347,7 +347,7 @@ function unit_test_client(verbose=true)
             #
             rc,rp_bits = report_slave_id(ctx_cl, NB_REPORT_SLAVE_ID)
             # Run status indicator is ON
-            @test_broken rc > 1 && rp_bits[2] == 0xFF
+            @test rc > 1 && rp_bits[2] == 0xFF
             length(rp_bits) > 2 && println(String(rp_bits[3:end]))
 
             # Save original timeout


### PR DESCRIPTION
Removed the colors from the Base.show() implementation for ModbusContexts so they display properly regardless of terminal color schemes, usage in logs, etc.

Thanks!